### PR TITLE
Wrap only Markdown

### DIFF
--- a/packages/ui/src/css/codemirror-tweaks.sass
+++ b/packages/ui/src/css/codemirror-tweaks.sass
@@ -6,9 +6,3 @@
 
 .react-codemirror2, .code-editor-container
   height: 100%
-
-// Break on characters, so that the split pane can
-// be resized, and the CodeMirror editor doesn't
-// stubbornly take up the width of the longest unbreakable word.
-.CodeMirror-wrap pre
-  word-break: break-all;

--- a/packages/ui/src/css/editorGrid.sass
+++ b/packages/ui/src/css/editorGrid.sass
@@ -26,4 +26,5 @@
       display: block
   .editor-grid-center
     flex: 1 1 auto
+    min-width: 0
 

--- a/packages/ui/src/visualizationEditor/codeEditor.js
+++ b/packages/ui/src/visualizationEditor/codeEditor.js
@@ -39,6 +39,7 @@ const modes = {
 };
 const extension = fileName => fileName.substr(fileName.lastIndexOf('.'));
 const getMode = fileName => modes[extension(fileName)];
+const getLineWrapping = fileName => extension(fileName) !== '.js';
 
 export class CodeEditor extends Component {
 
@@ -74,7 +75,7 @@ export class CodeEditor extends Component {
             mode: getMode(fileName),
             theme: 'ubuntu',
             lineNumbers: true,
-            lineWrapping: true,
+            lineWrapping: getLineWrapping(fileName),
             keyMap: 'sublime',
             autoCloseBrackets: true,
             matchBrackets: true,

--- a/packages/ui/src/visualizationEditor/codeEditor.js
+++ b/packages/ui/src/visualizationEditor/codeEditor.js
@@ -39,7 +39,7 @@ const modes = {
 };
 const extension = fileName => fileName.substr(fileName.lastIndexOf('.'));
 const getMode = fileName => modes[extension(fileName)];
-const getLineWrapping = fileName => extension(fileName) !== '.js';
+const getLineWrapping = fileName => extension(fileName) === '.md';
 
 export class CodeEditor extends Component {
 

--- a/packages/ui/src/visualizationEditor/codeEditor.js
+++ b/packages/ui/src/visualizationEditor/codeEditor.js
@@ -37,9 +37,9 @@ const modes = {
   '.js': 'jsx',
   '.md': 'markdown'
 };
-const extension = fileName => fileName.substr(fileName.lastIndexOf('.'));
-const getMode = fileName => modes[extension(fileName)];
-const getLineWrapping = fileName => extension(fileName) === '.md';
+const getExtension = fileName => fileName.substr(fileName.lastIndexOf('.'));
+const getMode = extension => modes[extension];
+const getLineWrapping = extension => extension === '.md';
 
 export class CodeEditor extends Component {
 
@@ -59,6 +59,7 @@ export class CodeEditor extends Component {
 
   render() {
     const { fileName, value, onTextChange } = this.props;
+    const extension = getExtension(fileName);
 
     if (!process.browser) {
       return null;
@@ -72,10 +73,10 @@ export class CodeEditor extends Component {
         <CodeMirror
           value={value}
           options={{
-            mode: getMode(fileName),
+            mode: getMode(extension),
             theme: 'ubuntu',
             lineNumbers: true,
-            lineWrapping: getLineWrapping(fileName),
+            lineWrapping: getLineWrapping(extension),
             keyMap: 'sublime',
             autoCloseBrackets: true,
             matchBrackets: true,


### PR DESCRIPTION
Before:

 * Wrap all files on characters

After:

 * Wrap only Markdown (.md) files, as these tend to have paragraphs long single lines.
 * Wrap on words (like in GitHub issues)

 Closes #63 

The reason for this change is that the wrapping was getting in the way while working.