### PR TITLE
Disable autoCloseBrackets

### DIFF
--- a/packages/ui/src/visualizationEditor/codeEditor.js
+++ b/packages/ui/src/visualizationEditor/codeEditor.js
@@ -18,7 +18,6 @@ if (process.browser) {
   require('codemirror/addon/search/search.js');
   require('codemirror/addon/dialog/dialog.js');
   require('codemirror/addon/edit/matchbrackets.js');
-  require('codemirror/addon/edit/closebrackets.js');
   require('codemirror/addon/wrap/hardwrap.js');
   require('codemirror/addon/fold/foldcode.js');
   require('codemirror/addon/fold/brace-fold.js');
@@ -76,7 +75,6 @@ export class CodeEditor extends Component {
             lineNumbers: true,
             lineWrapping: true,
             keyMap: 'sublime',
-            autoCloseBrackets: true,
             matchBrackets: true,
             showCursorWhenSelecting: true,
             tabSize: 2


### PR DESCRIPTION
Closes #168

I found myself more often than not fighting with this feature, and found it more harmful than helpful. For example, when trying to change quotes from double to single, it would automatically insert unwanted characters that I'd need to clean up. Also with deeply nested parens or braces, it was frustrating that typing a new brace in the middle of a sequence of closing braces would not add one to the list.